### PR TITLE
Little performance improvement

### DIFF
--- a/src/Orchestra/Traits/AccessibleTrait.php
+++ b/src/Orchestra/Traits/AccessibleTrait.php
@@ -38,7 +38,7 @@ trait AccessibleTrait
     public function __call($method, $value = null)
     {
         // Handle a get method on a service
-        if (preg_match('/^get/', $method)) {
+        if (strpos($method, 'get') === 0) {
             $property = lcfirst(substr($method, 3));
             if (!isset($this->{$property})) {
                 $property = Strings::toUnderscores($property);
@@ -47,7 +47,7 @@ trait AccessibleTrait
         }
 
         // Handle a set method on a service
-        if (preg_match('/^set/', $method)) {
+        if (strpos($method, 'set') === 0) {
             if (is_array($value) && !empty($value)) {
                 $this->set(lcfirst(substr($method, 3)), $value[0]);
             }


### PR DESCRIPTION
As the [PHP Manual](http://php.net/manual/en/function.preg-match.php) says:

> Do not use preg_match() if you only want to check if one string is contained in another string. Use strpos() instead as it will be faster.